### PR TITLE
fix: arrumando dependências do ubuntu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,36 +12,37 @@ distro=$(grep "^ID=" /etc/os-release | awk -F= '{print tolower($2)}' | tr -d '"'
 
 # Define os pacotes com base nas distros-mãe
 pacotes_debian_base="pulseaudio-utils dbus-python-devel python3-dbus google-chrome-stable"
-# python3-dbus não existe no apt. então, é necessário instalar as bibliotecas do dbus e suas dependências separadamente
-pacotes_ubuntu_base="pulseaudio-utils build-essential libdbus-glib-1-dev libgirepository1.0-dev google-chrome-stable"
-pacotes_rhel_base="pulseaudio-utils dbus-python-devel python3-dbus google-chrome-stable"
+pacotes_rhel_base="pulseaudio-utils python3-dbus google-chrome-stable"
 
 # TODO: testei os IDs só para rhel, fedora, debian, ubuntu e vi que no centos às vezes tem IDs diferentes a depender da versão, mas deixei a "padrão"
 
 # função para checar de keyring do Google Chrome existe
 # ao rodar o install.sh, tive erros pra instalar o google-chrome-stable. 
 # o erro era que o pacote não existia, então adicionei essa função para instalar o keyring caso não seja encontrado
-check_google_keyring() {
+check_google() {
+	CAMINHO_CHROME=$(whereis google-chrome-stable | awk '{print $2}')
+	
+	if [ -n "$CAMINHO_CHROME" ]; then
+		echo "Google Chrome encontrado no sistema. Pulando instalação..."
+		return
+	fi
+
 	if [ -f "/etc/apt/keyrings/google-chrome.gpg" ]; then
 		echo "Keyring do Google encontrado. Continuando instalação..."
 	else
 		echo "Keyring do Google não foi encontrado. Instalando keyring..."
-		wget https://dl-ssl.google.com/linux/linux_signing_key.pub -O /tmp/google.pub
+		wget -qO https://dl-ssl.google.com/linux/linux_signing_key.pub -O /tmp/google.pub
 		gpg --no-default-keyring --keyring /etc/apt/keyrings/google-chrome.gpg --import /tmp/google.pub
-		echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
+		echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list > /dev/null
 		rm /tmp/google.pub
 	fi
 }
 
 # Instala os pacotes de acordo com a distribuição
-if [[ "$distro" == "debian" ]]; then
+if [[ "$distro" == "ubuntu" || "$distro" == "debian" ]]; then
+	check_google
 	apt update -y
 	apt install -y $pacotes_debian_base
-
-elif [[ "$distro" == "ubuntu" ]]; then
-	check_google_keyring
-	apt update -y
-	apt install -y $pacotes_ubuntu_base
 
 elif [[ "$distro" == "rhel" || "$distro" == "fedora" || "$distro" == "centos" ]]; then
 	dnf update -y

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ distro=$(grep "^ID=" /etc/os-release | awk -F= '{print tolower($2)}' | tr -d '"'
 
 # Define os pacotes com base nas distros-mãe
 pacotes_debian_base="pulseaudio-utils dbus-python-devel python3-dbus google-chrome-stable"
-pacotes_rhel_base="pulseaudio-utils python3-dbus google-chrome-stable"
+pacotes_rhel_base="pulseaudio-utils dbus-python-devel python3-dbus google-chrome-stable"
 
 # TODO: testei os IDs só para rhel, fedora, debian, ubuntu e vi que no centos às vezes tem IDs diferentes a depender da versão, mas deixei a "padrão"
 

--- a/install.sh
+++ b/install.sh
@@ -12,14 +12,36 @@ distro=$(grep "^ID=" /etc/os-release | awk -F= '{print tolower($2)}' | tr -d '"'
 
 # Define os pacotes com base nas distros-mãe
 pacotes_debian_base="pulseaudio-utils dbus-python-devel python3-dbus google-chrome-stable"
+# python3-dbus não existe no apt. então, é necessário instalar as bibliotecas do dbus e suas dependências separadamente
+pacotes_ubuntu_base="pulseaudio-utils build-essential libdbus-glib-1-dev libgirepository1.0-dev google-chrome-stable"
 pacotes_rhel_base="pulseaudio-utils dbus-python-devel python3-dbus google-chrome-stable"
 
 # TODO: testei os IDs só para rhel, fedora, debian, ubuntu e vi que no centos às vezes tem IDs diferentes a depender da versão, mas deixei a "padrão"
 
+# função para checar de keyring do Google Chrome existe
+# ao rodar o install.sh, tive erros pra instalar o google-chrome-stable. 
+# o erro era que o pacote não existia, então adicionei essa função para instalar o keyring caso não seja encontrado
+check_google_keyring() {
+	if [ -f "/etc/apt/keyrings/google-chrome.gpg" ]; then
+		echo "Keyring do Google encontrado. Continuando instalação..."
+	else
+		echo "Keyring do Google não foi encontrado. Instalando keyring..."
+		wget https://dl-ssl.google.com/linux/linux_signing_key.pub -O /tmp/google.pub
+		gpg --no-default-keyring --keyring /etc/apt/keyrings/google-chrome.gpg --import /tmp/google.pub
+		echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
+		rm /tmp/google.pub
+	fi
+}
+
 # Instala os pacotes de acordo com a distribuição
-if [[ "$distro" == "ubuntu" || "$distro" == "debian" ]]; then
+if [[ "$distro" == "debian" ]]; then
 	apt update -y
 	apt install -y $pacotes_debian_base
+
+elif [[ "$distro" == "ubuntu" ]]; then
+	check_google_keyring
+	apt update -y
+	apt install -y $pacotes_ubuntu_base
 
 elif [[ "$distro" == "rhel" || "$distro" == "fedora" || "$distro" == "centos" ]]; then
 	dnf update -y
@@ -30,5 +52,6 @@ else
 	exit 1
 fi
 
+# TODO: avaliar a necessidade de utilizar um venv para rodar o pip install. ao rodar o install.sh sem o venv, recebi o erro "externally-managed-environment".
 pip install -r requirements.txt
 


### PR DESCRIPTION
Troca das dependências do python3-dbus. No apt, essa package não existe, então troquei para instalar cada uma das dependências do dbus separadamente. Além disso, fiz uma função para checagem do keyring do google chrome, já que o apt não consegue encontrar o google-chrome-stable sem esse keyring.